### PR TITLE
add functionality if no vidoes are available from fetch

### DIFF
--- a/src/Components/Details/Details.tsx
+++ b/src/Components/Details/Details.tsx
@@ -9,73 +9,79 @@ import mockdata from '../../mock-data-dana';
 
 
 interface DetailsProps {
-  myCreators: Creator[];
-  follows: number[]; 
+	myCreators: Creator[];
+	follows: number[];
 }
 
 function Details({ myCreators, follows }: DetailsProps) {
-  const { id } = useParams(); 
+	const { id } = useParams();
 
-  const [selectedButton, setSelectedButton] = useState<string>('youtube'); 
+	const [selectedButton, setSelectedButton] = useState<string>('youtube');
 
-  const handleButtonClick = (buttonId: string) => {
-    setSelectedButton(buttonId);
-  };
+	const handleButtonClick = (buttonId: string) => {
+		setSelectedButton(buttonId);
+	};
 
-  useEffect(() => {
-    console.log("button changed to: ", selectedButton)
-  }, [selectedButton])
+	useEffect(() => {
+		console.log("button changed to: ", selectedButton)
+	}, [selectedButton])
 
 
-  const creator = myCreators.find(creator => creator.id === parseInt(id || '', 10));
+	const creator = myCreators.find(creator => creator.id === parseInt(id || '', 10));
 
-  return (
-    <div className='details'>
-      {creator && (
-        <>
-          <h2>{creator.attributes.name}'s Details</h2>
-          <div className="socials-header">
-            <button
-              className={selectedButton === 'youtube' ? 'selected' : ''}
-              onClick={() => handleButtonClick('youtube')}
-            >
-              Youtube
-            </button>
-            <button
-              className={selectedButton === 'twitch' ? 'selected' : ''}
-              onClick={() => handleButtonClick('twitch')}
-            >
-              Twitch
-            </button>
-            <button
-              className={selectedButton === 'ect' ? 'selected' : ''}
-              onClick={() => handleButtonClick('ect')}
-            >
-              Etc.
-            </button>
-          </div>
-          {selectedButton === 'youtube' && (
-            <>
-              {creator.attributes.youtube_videos.map(video => (
-                <Youtube key={video.id} videoId={video.id} />
-              ))}
-            </>
-          )}
-          {selectedButton === 'twitch' && (
-            <>
-           {selectedButton === 'twitch' && (
+	return (
+		<div className='details'>
+			{creator && (
 				<>
-					{mockdata.data[1].attributes.youtube_videos.map(video => (
-						<Twitch key={video.id} videoId={video.id} />
-					))}
+					<h2>{creator.attributes.name}'s Details</h2>
+					<div className="socials-header">
+						<button
+							className={selectedButton === 'youtube' ? 'selected' : ''}
+							onClick={() => handleButtonClick('youtube')}
+						>
+							Youtube
+						</button>
+						<button
+							className={selectedButton === 'twitch' ? 'selected' : ''}
+							onClick={() => handleButtonClick('twitch')}
+						>
+							Twitch
+						</button>
+						<button
+							className={selectedButton === 'ect' ? 'selected' : ''}
+							onClick={() => handleButtonClick('ect')}
+						>
+							Etc.
+						</button>
+					</div>
+
+					{selectedButton === 'youtube' && (
+						<>
+							{mockdata.data[0].attributes.youtube_videos.length === 0 ? (
+								<p>No videos available for this section</p>
+							) : (
+								mockdata.data[0].attributes.youtube_videos.map(video => (
+									<Youtube key={video.id} videoId={video.id} />
+								))
+							)}
+						</>
+					)}
+					{selectedButton === 'twitch' && (
+						<>
+							{mockdata.data[1].attributes.youtube_videos.length === 0 ? (
+								<p>No videos available for this section</p>
+							) : (
+								mockdata.data[1].attributes.youtube_videos.map(video => (
+									<Twitch key={video.id} videoId={video.id} />
+								))
+							)}
+						</>
+					)}
+
 				</>
 			)}
-            </>
-          )}
-        </>
-      )}
-    </div>
-  );
+		</div>
+	);
 };
 
 export default Details;


### PR DESCRIPTION
## Description
Briefly describe the purpose and goal of this pull request.
Add functionality for if the fetch request has no Youtube videos/ Twitch videos available for display, then a message saying there are videos available will display instead.. 

## What type of PR is this? (check all applicable)
- [x] 💡💫 Feature
- [ ] 🐞🐛 Fix
- [ ] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dana, Gavin

## Changes
List the changes introduced by this pull request.
Changed Details.tsx to display the correct message if no videos are available.

## Related Issues
Indicate any related issues that this pull request addresses or resolves.

## How Has This Been Tested?
Describe testing implemented and what all it covers.
- [] (fill out testing done here)
- [] (additional placement for more testing)
- [x] Is not applicable to this PR

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [ ] I have added/updated unit tests (if applicable).
- [ ] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.

### Thanks, GO TEAM! 👏
