### PR TITLE
Feat/twitch intergration

### DIFF
--- a/src/Components/Details/Details.tsx
+++ b/src/Components/Details/Details.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Creator } from '../../types';
 import mockdata from '../../mock-data-dana';
+import mockTwitch from '../../mock-data-twitch';
 
 
 interface DetailsProps {
@@ -68,10 +69,10 @@ function Details({ myCreators, follows }: DetailsProps) {
 					)}
 					{selectedButton === 'twitch' && (
 						<>
-							{mockdata.data[1].attributes.youtube_videos.length === 0 ? (
+							{mockTwitch.data.attributes.twitch_videos.length === 0 ? (
 								<p>No videos available for this section</p>
 							) : (
-								mockdata.data[1].attributes.youtube_videos.map(video => (
+								mockTwitch.data.attributes.twitch_videos.map (video => (
 									<Twitch key={video.id} videoId={video.id} />
 								))
 							)}

--- a/src/Components/Twitch/Twitch.tsx
+++ b/src/Components/Twitch/Twitch.tsx
@@ -8,10 +8,11 @@ interface TwtichProps {
 const Twitch: React.FC<TwtichProps> = ({ videoId }) => {
 	// Construct the URL of the embedded YouTube video
 	// const youtubeUrl = `https://www.youtube.com/embed/${videoId}`; will use later with actual twtich data
-
+	const twitchURL = `https://player.twitch.tv/?video=v${videoId}&parent=capstonefrontend-dun.vercel.app&autoplay=false`
 	return (
 		<div className='twitch_card'>
-			<iframe src="https://player.twitch.tv/?channel=esl_dota2earth&parent=capstonefrontend-dun.vercel.app"
+			<iframe
+				src={twitchURL}
 				allowFullScreen
 				scrolling="no"
 				height="378"

--- a/src/mock-data-twitch.tsx
+++ b/src/mock-data-twitch.tsx
@@ -1,0 +1,75 @@
+const mockTwitch = {
+	"data": {
+			"id": 1,
+			"type": "creator_aggregation",
+			"attributes": {
+					"name": "ZFG",
+					"youtube_videos": [
+							{
+									"id": "v-S-oXltLGY",
+									"image": "https://i.ytimg.com/vi/v-S-oXltLGY/hqdefault.jpg",
+									"publishedAt": "2024-02-27T03:20:10Z",
+									"title": "Majora&#39;s Mask Randomizer - February 19th 2024"
+							},
+							{
+									"id": "tTlv1GO1jws",
+									"image": "https://i.ytimg.com/vi/tTlv1GO1jws/hqdefault.jpg",
+									"publishedAt": "2024-02-27T03:19:40Z",
+									"title": "Majora&#39;s Mask Randomizer - February 16th 2024"
+							},
+							{
+									"id": "yiFVunlhK1Y",
+									"image": "https://i.ytimg.com/vi/yiFVunlhK1Y/hqdefault.jpg",
+									"publishedAt": "2024-02-27T03:20:19Z",
+									"title": "Majora&#39;s Mask Randomizer - February 23rd 2024"
+							},
+							{
+									"id": "ULqw1UW9d_4",
+									"image": "https://i.ytimg.com/vi/ULqw1UW9d_4/hqdefault.jpg",
+									"publishedAt": "2024-02-27T03:20:50Z",
+									"title": "Majora&#39;s Mask 2v1 Randomizer race vs @NinanininVT  and @BatAtVideoGames -  February 24th 2024"
+							},
+							{
+									"id": "lMn5g_K--GA",
+									"image": "https://i.ytimg.com/vi/lMn5g_K--GA/hqdefault.jpg",
+									"publishedAt": "2024-02-27T03:19:52Z",
+									"title": "Majora&#39;s Mask Randomizer - February 17th 2024"
+							}
+					],
+					"twitch_videos": [
+							{
+									"id": "2100415767",
+									"title": "Majora's Mask Randomizer - No Logic and no starting items",
+									"published_at": "2024-03-24T19:54:27Z",
+									"image": "https://static-cdn.jtvnw.net/cf_vods/d1m7jfoe9zdc1j/250dc318e19581f58b64_zfg1_42444153433_1711310062//thumb/thumb0-%{width}x%{height}.jpg"
+							},
+							{
+									"id": "2098300556",
+									"title": "Majora's Mask Randomizer - No Logic and no starting items",
+									"published_at": "2024-03-22T19:19:52Z",
+									"image": "https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/b34fe3a30a896b8ae433_zfg1_43873415179_1711135187//thumb/thumb0-%{width}x%{height}.jpg"
+							},
+							{
+									"id": "2096513754",
+									"title": "Majora's Mask Randomizer with enemies randomized",
+									"published_at": "2024-03-20T20:18:05Z",
+									"image": "https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/4ec8f9e58698d909dca5_zfg1_43860356251_1710965880//thumb/thumb0-%{width}x%{height}.jpg"
+							},
+							{
+									"id": "2094644583",
+									"title": "Majora's Mask Randomizer with everything randomized",
+									"published_at": "2024-03-18T20:00:43Z",
+									"image": "https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/47bd79407c67f621fa95_zfg1_43846917963_1710792038//thumb/thumb0-%{width}x%{height}.jpg"
+							},
+							{
+									"id": "2092737221",
+									"title": "Majora's Mask Randomizer with everything randomized",
+									"published_at": "2024-03-16T19:53:15Z",
+									"image": "https://static-cdn.jtvnw.net/cf_vods/d1m7jfoe9zdc1j/31ff66e0be8089e26863_zfg1_50648550989_1710618791//thumb/thumb0-%{width}x%{height}.jpg"
+							}
+					]
+			}
+	}
+}
+
+export default mockTwitch;


### PR DESCRIPTION
## Description
Briefly describe the purpose and goal of this pull request.
Changed the Twtich integration to display vod instead of streams, allowing us to use the data from the backend repo. Properly set up the embedded Twitch to display on the deployed webpage.
## What type of PR is this? (check all applicable)
- [x] 💡💫 Feature
- [x] 🐞🐛 Fix
- [x] 🪸🎭 Refactor
- [ ] 💅🎨 Style
- [ ] 📄💾 Documentation

## Reviewers
Dana, Gavin

## Changes
List the changes introduced by this pull request.
Added Twitch mock data(same as backend data, just no fetch request)
Refactored embedded Twitch videos


## Related Issues
Indicate any related issues that this pull request addresses or resolves.


## How Has This Been Tested?
Describe testing implemented and what all it covers.
- [ ] (fill out testing done here)
- [ ] (additional placement for more testing)
- [x] Is not applicable to this PR

## Checklist
- [x] I have read the contribution guidelines.
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] Documentation has been updated (if applicable).
- [x] I have added/updated unit tests (if applicable).
- [x] I have squashed/organized my commits.

## Additional Notes
Add any additional information that might be relevant for reviewers.
The embedded Twitch CANNOT run on a localhost::3000, as the iframe holds the Twitch src cannot use localhost::3000 as a parent element. This means that you have to go to the deployed webpage and edit the elements manually to see any Twitch changes.

### Thanks, GO TEAM! 👏
